### PR TITLE
Use urlFor() instead of hard-coded strings

### DIFF
--- a/src/org/scharp/atlas/pepdb/view/importPeptides.jsp
+++ b/src/org/scharp/atlas/pepdb/view/importPeptides.jsp
@@ -1,15 +1,16 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page import="org.labkey.api.view.HttpView"%>
 <%@ page import="org.labkey.api.view.JspView"%>
-<%@ page import="org.scharp.atlas.pepdb.PepDBController" %>
+<%@ page import="org.scharp.atlas.pepdb.PepDBBaseController.FileForm" %>
+<%@ page import="org.scharp.atlas.pepdb.PepDBController.ImportPeptidesAction" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <div>
     <%
-        JspView<PepDBController.FileForm> me = (JspView<PepDBController.FileForm>) HttpView.currentView();
-        PepDBController.FileForm bean = me.getModelBean();
+        JspView<FileForm> me = (JspView<FileForm>) HttpView.currentView();
+        FileForm bean = me.getModelBean();
     %>
     <labkey:errors/>
-    <labkey:form name="FileForm" action="importPeptides.post" method="POST" enctype="multipart/form-data">
+    <labkey:form name="FileForm" action="<%=urlFor(ImportPeptidesAction.class)%>" method="POST" enctype="multipart/form-data">
         <table class="normal">
             <tr>
                 <td colspan="3">

--- a/src/org/scharp/atlas/pepdb/view/importPools.jsp
+++ b/src/org/scharp/atlas/pepdb/view/importPools.jsp
@@ -1,7 +1,8 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page import="org.labkey.api.view.HttpView"%>
-<%@ page import="org.scharp.atlas.pepdb.PepDBController" %>
 <%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.scharp.atlas.pepdb.PepDBController" %>
+<%@ page import="org.scharp.atlas.pepdb.PepDBController.ImportPeptidePoolsAction" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <div>
     <%
@@ -14,7 +15,7 @@
     <%}%>
 
     <labkey:errors/>
-    <labkey:form name="FileForm" action="importPeptidePools.post" method="POST" enctype="multipart/form-data">
+    <labkey:form name="FileForm" action="<%=urlFor(ImportPeptidePoolsAction.class)%>" method="POST" enctype="multipart/form-data">
         <table class="normal">
             <tr>
                 <td colspan="3">

--- a/src/org/scharp/atlas/pepdb/view/index.jsp
+++ b/src/org/scharp/atlas/pepdb/view/index.jsp
@@ -3,7 +3,8 @@
 <%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.ViewContext" %>
-<%@ page import="org.scharp.atlas.pepdb.PepDBController" %>
+<%@ page import="org.scharp.atlas.pepdb.PepDBBaseController.DisplayPeptideForm" %>
+<%@ page import="org.scharp.atlas.pepdb.PepDBController.DisplayPeptideAction" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%  ViewContext ctx = getViewContext();
@@ -31,9 +32,9 @@
 </ul>
 <labkey:errors/>
 <%
-    PepDBController.DisplayPeptideForm form = (PepDBController.DisplayPeptideForm) (HttpView.currentModel());
+    DisplayPeptideForm form = (DisplayPeptideForm) (HttpView.currentModel());
 %>
-<labkey:form action="displayPeptide.view" method="get">
+<labkey:form action="<%=urlFor(DisplayPeptideAction.class)%>" method="get">
 Lookup Peptide by Id: <input type="text" name="peptide_id" size="10" value="<%=h(form.getPeptide_id())%>"/> &nbsp; <%= button("Find").submit(true) %>
 </labkey:form>
 <p>

--- a/src/org/scharp/atlas/pepdb/view/peptideGroupSelect.jsp
+++ b/src/org/scharp/atlas/pepdb/view/peptideGroupSelect.jsp
@@ -2,6 +2,7 @@
 <%@ page import="org.labkey.api.view.HttpView"%>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.scharp.atlas.pepdb.PepDBBaseController.PeptideQueryForm" %>
+<%@ page import="org.scharp.atlas.pepdb.PepDBController.SearchForPeptidesAction" %>
 <%@ page import="org.scharp.atlas.pepdb.PepDBManager" %>
 <%@ page import="org.scharp.atlas.pepdb.PepDBSchema" %>
 <%@ page import="org.scharp.atlas.pepdb.model.PeptideGroup" %>
@@ -21,7 +22,7 @@
     }
 </script>
 <labkey:errors/>
-<labkey:form name="PeptideQueryForm" action="searchForPeptides.post" method="post">
+<labkey:form name="PeptideQueryForm" action="<%=urlFor(SearchForPeptidesAction.class)%>" method="post">
     <h3 align="left" style="color:blue">Search for Peptides using different criteria : </h3><br><br>
     <table>
         <tr>


### PR DESCRIPTION
#### Rationale
Use `urlFor()` instead of hard-coded strings.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549