### PR TITLE
Migrate use of boxed primitive constructors

### DIFF
--- a/src/org/scharp/atlas/pepdb/PepDBBaseController.java
+++ b/src/org/scharp/atlas/pepdb/PepDBBaseController.java
@@ -663,9 +663,9 @@ public class PepDBBaseController extends SpringActionController
 
     public static Integer validateInteger(String value)
     {
-        try{
-            Integer intValue = new Integer(value);
-            return intValue;
+        try
+        {
+            return Integer.valueOf(value);
         }
         catch(NumberFormatException e){return null;}
     }
@@ -690,12 +690,10 @@ public class PepDBBaseController extends SpringActionController
 
     public static Float validateFloat(String value)
     {
-        try{
-            Float floatValue = new Float(value);
-            return floatValue;
+        try
+        {
+            return Float.valueOf(value);
         }
         catch(NumberFormatException e){return null;}
     }
-
-
 }

--- a/src/org/scharp/atlas/pepdb/PeptideImporter.java
+++ b/src/org/scharp/atlas/pepdb/PeptideImporter.java
@@ -305,9 +305,9 @@ public class PeptideImporter
 
     public static Integer validateInteger(String value)
     {
-        try{
-            Integer intValue = new Integer(value);
-            return intValue;
+        try
+        {
+            return Integer.valueOf(value);
         }
         catch(NumberFormatException e){return null;}
     }


### PR DESCRIPTION
#### Rationale
"Boxed primitive constructors" (e.g., `new Double(0.23457)`) have been deprecated since JDK 9 and marked for removal as of JDK 16. Migrate away from them to reduce warnings.