### PR TITLE
Remove SupportedDatabases property now that default is PostgreSQL-only

### DIFF
--- a/module.properties
+++ b/module.properties
@@ -1,3 +1,2 @@
 ModuleClass: org.scharp.atlas.pepdb.PepDBModule
-SupportedDatabases: pgsql
 ManageVersion: false


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6067